### PR TITLE
Create container for qupath-project-initializer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'groovy'
     id 'com.github.johnrengelman.shadow' version '8.1.1'
     id 'org.jetbrains.kotlin.jvm'
+    id 'application'
 }
 
 group = 'org.example'
@@ -22,12 +23,8 @@ java {
     }
 }
 
-jar {
-    manifest {
-        attributes(
-                'Main-Class': 'KotlinMainKt'
-        )
-    }
+application {
+    mainClassName = 'KotlinMainKt'
 }
 
 dependencies {

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,0 +1,22 @@
+FROM gradle:8.5-jdk21-jammy AS build
+
+# Add the repo sha to the container as the version.
+ADD https://api.github.com/repos/dchaley/qupath-project-initializer/git/refs/heads/main version.json
+
+# Clone the repo
+RUN git clone https://github.com/dchaley/qupath-project-initializer.git /home/gradle/src
+
+WORKDIR "/home/gradle/src"
+
+# Build the shadow-jar which contains ALL dependencies
+RUN gradle shadowJar --no-daemon -Dorg.gradle.welcome=never
+
+# We can probably use a smaller base? Eg we don't need all the archs on GCP.
+# But for now– we're doing this.
+FROM eclipse-temurin:21-jre-jammy
+
+RUN mkdir /app
+
+COPY --from=build /home/gradle/src/build/libs/*-all.jar /app/
+
+ENTRYPOINT ["java","-jar","/app/qupath-project-initializer-1.0-SNAPSHOT-all.jar"]


### PR DESCRIPTION
This builds a container the "naive" way (aka no smart dependency layering). The container contains a "mega jar", built using `shadowJar` which contains all dependencies.

Fixes #9 