### PR TITLE
Download remote image inputs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,6 @@ dependencies {
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 
-    implementation group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.13'
-
     // https://mvnrepository.com/artifact/io.github.qupath/qupath-core
     implementation group: 'io.github.qupath', name: 'qupath-core', version: '0.5.1'
     implementation group: 'io.github.qupath', name: 'qupath-core-processing', version: '0.5.1'

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,8 @@ dependencies {
     implementation platform('com.google.cloud:libraries-bom:26.43.0')
     implementation 'com.google.cloud:google-cloud-storage'
 
+    implementation group: 'commons-io', name: 'commons-io', version: '2.16.1'
+
     // Kotlin stdlib
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,12 @@ dependencies {
     implementation group: 'ome', name: 'formats-gpl', version: '7.3.1'
 
     implementation group: 'io.github.qupath', name: 'qupath-extension-bioformats', version: '0.5.1'
+
+    // Google Cloud APIs
+    implementation platform('com.google.cloud:libraries-bom:26.43.0')
+    implementation 'com.google.cloud:google-cloud-storage'
+
+    // Kotlin stdlib
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 }
 

--- a/src/main/java/Inputs.kt
+++ b/src/main/java/Inputs.kt
@@ -1,0 +1,58 @@
+import com.google.cloud.storage.BlobId
+import com.google.cloud.storage.Storage
+import com.google.cloud.storage.StorageOptions
+import com.google.cloud.storage.transfermanager.ParallelDownloadConfig
+import com.google.cloud.storage.transfermanager.TransferManager
+import com.google.cloud.storage.transfermanager.TransferManagerConfig
+import org.apache.commons.io.FileUtils
+import java.io.File
+import java.net.URI
+import java.nio.file.Files
+
+
+data class InputImage(val imageName: String, val uri: URI, val localPath: String? = null)
+
+fun listGsInputs(uri: String, filter: String?, extension: String): List<InputImage> {
+  val storage: Storage = StorageOptions.getDefaultInstance().getService()
+  val rootBlobId = BlobId.fromGsUtilUri(uri)
+
+  // Return all objects that:
+  // - aren't directories
+  // - contain the filter string
+  // - end with the specified extension
+  return storage.list(rootBlobId.bucket, Storage.BlobListOption.prefix(rootBlobId.name)).iterateAll()
+    .mapNotNull { blob ->
+      if (blob.name.endsWith("/")
+        || !blob.name.contains(filter.orEmpty(), ignoreCase = true)
+        || !blob.name.endsWith(extension, ignoreCase = true)
+      ) {
+        return@mapNotNull null
+      }
+
+      InputImage(blob.name, URI.create("gs://${blob.bucket}/${blob.name}"))
+    }
+}
+
+fun listFileInputs(dirPath: String, extension: String, filter: String?): List<InputImage> {
+  return File(dirPath).walk().mapNotNull {
+    if (!it.isFile
+      || !it.name.contains(filter.orEmpty(), ignoreCase = true)
+      || !it.name.endsWith(extension, ignoreCase = true)
+    ) {
+      return@mapNotNull null
+    }
+
+    InputImage(it.name, it.toURI(), it.canonicalPath)
+  }.toList()
+}
+
+fun getImageInputs(imagesPath: String, extension: String, imageFilter: String? = null): List<InputImage> {
+  val imagesRootUri = URI.create(imagesPath)
+
+  return if (imagesRootUri.scheme == "gs") {
+    listGsInputs(imagesPath, filter = imageFilter, extension = extension)
+  } else {
+    listFileInputs(imagesPath, filter = imageFilter, extension = extension)
+  }
+}
+

--- a/src/main/java/Inputs.kt
+++ b/src/main/java/Inputs.kt
@@ -1,13 +1,15 @@
 import com.google.cloud.storage.BlobId
+import com.google.cloud.storage.BlobInfo
 import com.google.cloud.storage.Storage
 import com.google.cloud.storage.StorageOptions
 import com.google.cloud.storage.transfermanager.ParallelDownloadConfig
-import com.google.cloud.storage.transfermanager.TransferManager
 import com.google.cloud.storage.transfermanager.TransferManagerConfig
+import com.google.cloud.storage.transfermanager.TransferStatus
 import org.apache.commons.io.FileUtils
 import java.io.File
 import java.net.URI
 import java.nio.file.Files
+import kotlin.io.path.Path
 
 
 data class InputImage(val imageName: String, val uri: URI, val localPath: String? = null)
@@ -29,7 +31,9 @@ fun listGsInputs(uri: String, filter: String?, extension: String): List<InputIma
         return@mapNotNull null
       }
 
-      InputImage(blob.name, URI.create("gs://${blob.bucket}/${blob.name}"))
+      // The blob name is the entire key including parent folders. Keep only the filename.
+      val fileName = Path(blob.name).fileName.toString()
+      InputImage(fileName, URI.create("gs://${blob.bucket}/${blob.name}"))
     }
 }
 
@@ -56,3 +60,62 @@ fun getImageInputs(imagesPath: String, extension: String, imageFilter: String? =
   }
 }
 
+fun fetchRemoteImages(inputImages: List<InputImage>): List<InputImage> {
+  // Create a location to store remote images.
+  val localRoot = Files.createTempDirectory("images").toFile()
+  // Delete it on process exit.
+  Runtime.getRuntime().addShutdownHook(Thread { FileUtils.forceDelete(localRoot) })
+
+  // Collect all remote paths that need downloading
+  val remoteBlobs = inputImages.filter { it.localPath == null }.map { BlobId.fromGsUtilUri(it.uri.toString()) }
+
+  // No remotes? Nothing to do.
+  if (remoteBlobs.isEmpty()) {
+    return inputImages
+  }
+
+  // We only support 1 remote bucket for now. Assert we only have one (or none).
+  remoteBlobs.map { it.bucket }.distinct().let {
+    require(it.size <= 1) { "All remote images must be in the same bucket, found: $it buckets" }
+  }
+
+  // The remote root is parent path of all remote blobs.
+  val remoteRoot = remoteBlobs.first().let {
+    BlobId.of(it.bucket, it.name.substring(0, it.name.lastIndexOf('/') + 1))
+  }
+
+  val transferManager = TransferManagerConfig.newBuilder()
+    .setAllowDivideAndConquerDownload(true).build().service
+
+  // .use auto-closes the transfer manager.
+  val results = transferManager.use {
+    val parallelDownloadConfig: ParallelDownloadConfig? =
+      ParallelDownloadConfig.newBuilder()
+        .setBucketName(remoteRoot.bucket)
+        .setStripPrefix(remoteRoot.name)
+        .setDownloadDirectory(localRoot.toPath())
+        .build()
+
+    it.downloadBlobs(
+      remoteBlobs.map { b -> BlobInfo.newBuilder(b).build() },
+      parallelDownloadConfig
+    ).downloadResults
+  }
+
+  results.forEach {
+    require(it.status == TransferStatus.SUCCESS) { "Failed to download ${it.input.name}: ${it.exception}" }
+  }
+
+  return inputImages.map { inputImage ->
+    // Skip inputs that already have local paths
+    if (inputImage.localPath != null) {
+      return@map inputImage
+    }
+
+    val localPath = File(localRoot, inputImage.imageName)
+    localPath.exists() || error("Couldn't find downloaded remote image ${inputImage.uri}, expected at: ${localPath.canonicalPath}")
+
+    // Replace the input w/o local path to one with the newly downloaded path.
+    inputImage.copy(localPath = localPath.canonicalPath)
+  }
+}

--- a/src/main/java/Invocation.kt
+++ b/src/main/java/Invocation.kt
@@ -10,10 +10,18 @@ sealed class Invocation(name: String) : OptionGroup(name) {
 }
 
 class WorkspaceLocation : Invocation("workspace") {
-  private val workspacePath: String by option("--workspace-path", help = "Root directory of the workspace").required()
-  private val imagesSubdir: String by option("--images-subdir", help = "Name of the folder containing OME-TIFF images").default("OMETIFF")
-  private val segMasksSubdir: String by option("--segmasks-subdir", help = "Name of the folder containing segmentation masks").default("SEGMASKS")
-  private val projectSubdir: String by option("--project-subdir", help = "Name of the folder to save QuPath project").default("QUPATH")
+  private val workspacePath: String by option(
+    "--workspace-path", help = "Root directory of the workspace",
+  ).required()
+  private val imagesSubdir: String by option(
+    "--images-subdir", help = "Name of the folder containing OME-TIFF images",
+  ).default("OMETIFF")
+  private val segMasksSubdir: String by option(
+    "--segmasks-subdir", help = "Name of the folder containing segmentation masks",
+  ).default("SEGMASKS")
+  private val projectSubdir: String by option(
+    "--project-subdir", help = "Name of the folder to save QuPath project",
+  ).default("QUPATH")
 
   override val imagesPath: String
     get() = "$workspacePath/$imagesSubdir"
@@ -24,9 +32,15 @@ class WorkspaceLocation : Invocation("workspace") {
 }
 
 class ExplicitLocations : Invocation("explicit") {
-  override val imagesPath: String by option("--images-path", help = "Directory containing OME-TIFF images").required()
-  override val segMasksPath: String by option("--segmasks-path", help = "Directory containing segmentation masks").required()
-  override val projectPath: String by option("--project-path", help = "Directory to save QuPath project").required()
+  override val imagesPath: String by option(
+    "--images-path", help = "Directory containing OME-TIFF images",
+  ).required()
+  override val segMasksPath: String by option(
+    "--segmasks-path", help = "Directory containing segmentation masks",
+  ).required()
+  override val projectPath: String by option(
+    "--project-path", help = "Directory to save QuPath project",
+  ).required()
   val outputPath: String? by option(help = "Output path for QuPath measurements")
 }
 

--- a/src/main/java/KotlinMain.kt
+++ b/src/main/java/KotlinMain.kt
@@ -58,7 +58,7 @@ class InitializeProject : CliktCommand() {
 
     println("---")
 
-    for (file in inputImages.mapNotNull { if (it.localPath == null) null else File(it.localPath) }) {
+    inputImages.mapNotNull { input -> input.localPath?.let { File(it) } }.forEach { file ->
       val imagePath = file.getCanonicalPath()
       println(imagePath)
 

--- a/src/main/java/KotlinMain.kt
+++ b/src/main/java/KotlinMain.kt
@@ -18,7 +18,6 @@ import qupath.lib.scripting.QP.fireHierarchyUpdate
 import qupath.lib.scripting.QP.resolveHierarchy
 import java.awt.image.BufferedImage
 import java.io.File
-import kotlin.math.max
 import kotlin.math.roundToInt
 
 fun getFiles(dir: File, extension: String, filter: String?): List<File> {
@@ -30,6 +29,7 @@ fun getFiles(dir: File, extension: String, filter: String?): List<File> {
   }
   return files
 }
+
 fun main(args: Array<String>) {
   println("Initializing QuPath project")
 

--- a/src/main/java/KotlinMain.kt
+++ b/src/main/java/KotlinMain.kt
@@ -4,6 +4,7 @@ import com.github.ajalt.clikt.parameters.groups.required
 import com.github.ajalt.clikt.parameters.options.option
 import ij.IJ
 import ij.process.ColorProcessor
+import org.slf4j.LoggerFactory
 import qupath.imagej.processing.RoiLabeling
 import qupath.imagej.tools.IJTools
 import qupath.lib.analysis.features.ObjectMeasurements
@@ -21,7 +22,7 @@ import java.io.File
 import kotlin.math.roundToInt
 
 fun main(args: Array<String>) {
-  println("Initializing QuPath project")
+  LoggerFactory.getLogger(InitializeProject::class.java).info("Initializing QuPath project")
 
   // This makes sure the scripting.QP import doesn't get "optimized" away
   // We need the import so that various static initializers are run.
@@ -38,13 +39,15 @@ class InitializeProject : CliktCommand() {
 
   private val imageFilter: String? by option("--image-filter", help = "Filter for image names (file base name)")
 
+  private val logger = LoggerFactory.getLogger(InitializeProject::class.java)
+
   override fun run() {
     val downsample = 1.0
     val plane = ImagePlane.getDefaultPlane()
 
     val directory = File(args.projectPath)
     if (!directory.exists()) {
-      println("No project directory, creating one!")
+      logger.info("No project directory, creating one!")
       directory.mkdirs()
     }
 
@@ -54,23 +57,21 @@ class InitializeProject : CliktCommand() {
 
     inputImages = fetchRemoteImages(inputImages)
 
-    println("Detected ${inputImages.size} input images: $inputImages")
-
-    println("---")
+    logger.info("Detected ${inputImages.size} input images: $inputImages")
 
     inputImages.mapNotNull { input -> input.localPath?.let { File(it) } }.forEach { file ->
       val imagePath = file.getCanonicalPath()
-      println(imagePath)
+      logger.debug("Considering: $imagePath")
 
       val support = ImageServerProvider.getPreferredUriImageSupport(BufferedImage::class.java, imagePath)
       val builder = support.builders[0]
 
       if (builder == null) {
-        println("No builder found for $imagePath")
-        continue
+        logger.info("No builder found for $imagePath; skipping")
+        return@forEach
       }
 
-      println("Adding: $imagePath")
+      logger.info("Adding ${file.name} using builder: ${builder.javaClass.simpleName}")
 
       val entry = project.addImage(builder)
 
@@ -88,7 +89,7 @@ class InitializeProject : CliktCommand() {
 
     val directoryOfMasks = File(args.segMasksPath)
     if (directoryOfMasks.exists()) {
-      println("Discovering mask files...")
+      logger.info("Discovering mask files...")
       val wholeCellFiles = mutableListOf<File>()
 
       directoryOfMasks.walk().forEach {
@@ -101,23 +102,22 @@ class InitializeProject : CliktCommand() {
         val imgName = entry.imageName
 
         val sample = imgName.substringAfterLast(":").substringBefore(".")
-        println(" >>> $sample")
+        logger.info(" >>> $sample")
         val imageData = entry.readImageData()
         val server = imageData.server
 
         val wholeCellMask1 = wholeCellFiles.find { it.name.contains("${sample}_") }
         if (wholeCellMask1 == null) {
-          println(" >>> MISSING MASK FILES!! <<<")
-          println()
+          logger.warn(" >>> MISSING MASK FILES!! For: $sample <<<")
           return@forEach
         }
 
         val imp = IJ.openImage(wholeCellMask1.absolutePath)
-        print(imp)
+        logger.info(imp.toString())
         val n = imp.statistics.max.toInt()
-        println("   Max Cell Label: $n")
+        logger.info("   Max Cell Label: $n")
         if (n == 0) {
-          println(" >>> No objects found! <<<")
+          logger.info(" >>> No objects found! <<<")
           return
         }
 
@@ -137,17 +137,17 @@ class InitializeProject : CliktCommand() {
 
         val pathObjects = rois.map { PathObjects.createDetectionObject(it) }
 
-        println("  Number of Pathobjects: ${pathObjects.size}")
+        logger.info("  Number of Pathobjects: ${pathObjects.size}")
         imageData.hierarchy.addObjects(pathObjects)
         resolveHierarchy()
         entry.saveImageData(imageData)
 
-        println(" >>> Calculating measurements...")
-        println(imageData.hierarchy)
+        logger.info(" >>> Calculating measurements...")
+        logger.info(imageData.hierarchy.toString())
         val numDetectionObjects = imageData.hierarchy.detectionObjects.size
-        println("  DetectionObjects: $numDetectionObjects")
+        logger.info("  DetectionObjects: $numDetectionObjects")
         val measurements = ObjectMeasurements.Measurements.entries
-        println("Computing intensity measurements: ${measurements}")
+        logger.info("Computing intensity measurements: ${measurements}")
 
         val updateAfterCount = when {
           numDetectionObjects == 1 -> 1
@@ -158,7 +158,7 @@ class InitializeProject : CliktCommand() {
 
         for ((processed, detection) in imageData.hierarchy.detectionObjects.withIndex()) {
           if (processed % updateAfterCount == 0) {
-            println("${(100 * processed.toFloat() / numDetectionObjects).roundToInt()}% complete")
+            logger.info("${(100 * processed.toFloat() / numDetectionObjects).roundToInt()}% complete")
           }
           ObjectMeasurements.addIntensityMeasurements(server, detection, downsample, measurements, listOf())
           ObjectMeasurements.addShapeMeasurements(
@@ -166,7 +166,7 @@ class InitializeProject : CliktCommand() {
             *ObjectMeasurements.ShapeFeatures.entries.toTypedArray()
           )
         }
-        println("100% complete: ${imgName}")
+        logger.info("100% complete: ${imgName}")
         fireHierarchyUpdate()
         entry.saveImageData(imageData)
         imageData.server.close()
@@ -174,7 +174,6 @@ class InitializeProject : CliktCommand() {
     }
 
     project.syncChanges()
-    println("")
-    println("Done.")
+    logger.info("Done.")
   }
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,28 @@
+<configuration>
+
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>
+
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n
+            </Pattern>
+        </layout>
+    </appender>
+
+    <logger name="qupath.lib.images.servers.bioformats" level="error"/>
+    <logger name="qupath.lib.io" level="warn"/>
+    <logger name="qupath.lib.gui" level="warn"/>
+    <logger name="qupath.lib.scripting" level="warn"/>
+    <logger name="loci.formats" level="warn"/>
+
+    <!--        <logger name="com.mkyong" level="debug" additivity="false">-->
+    <!--            <appender-ref ref="CONSOLE"/>-->
+    <!--        </logger>-->
+
+    <root level="info">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
This is the first part of #14  : downloading remote images to storage.

For any input image with a remote `gs://` path, download it to local temporary storage – then proceed as usual.

Next we need to find masks remotely, and download to local storage as well.