### PR TITLE
Download remote segmentation masks

### DIFF
--- a/src/main/java/Images.kt
+++ b/src/main/java/Images.kt
@@ -1,0 +1,49 @@
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import qupath.lib.gui.commands.ProjectCommands
+import qupath.lib.images.ImageData
+import qupath.lib.images.servers.ImageServerProvider
+import qupath.lib.projects.Project
+import java.awt.image.BufferedImage
+import java.io.File
+
+class Images {
+  companion object {
+    val logger: Logger = LoggerFactory.getLogger(Images::class.java)
+  }
+}
+
+fun Project<BufferedImage>.addImages(inputImages: List<InputImage>) {
+  val logger = Images.logger
+
+  inputImages
+    .mapNotNull { it.localPath }
+    .map { File(it) }
+    .forEach { file ->
+      val imagePath = file.getCanonicalPath()
+      logger.debug("Considering: $imagePath")
+
+      val support = ImageServerProvider.getPreferredUriImageSupport(BufferedImage::class.java, imagePath)
+      val builder = support.builders[0]
+
+      if (builder == null) {
+        logger.info("No builder found for $imagePath; skipping")
+        return@forEach
+      }
+
+      logger.info("Adding ${file.name} using builder: ${builder.javaClass.simpleName}")
+
+      val entry = this.addImage(builder)
+
+      val imageData = entry.readImageData()
+      imageData.imageType = ImageData.ImageType.FLUORESCENCE
+      entry.saveImageData(imageData)
+
+      val img = ProjectCommands.getThumbnailRGB(imageData.server)
+      entry.thumbnail = img
+
+      entry.imageName = file.name
+    }
+
+  this.syncChanges()
+}

--- a/src/main/java/Inputs.kt
+++ b/src/main/java/Inputs.kt
@@ -12,7 +12,7 @@ import java.nio.file.Files
 import kotlin.io.path.Path
 
 
-data class InputImage(val imageName: String, val uri: URI, val localPath: String? = null)
+data class InputImage(val imageName: String, val uri: URI, val localPath: String?)
 
 fun listGsInputs(uri: String, filter: String?, extension: String): List<InputImage> {
   val storage: Storage = StorageOptions.getDefaultInstance().getService()
@@ -33,7 +33,7 @@ fun listGsInputs(uri: String, filter: String?, extension: String): List<InputIma
 
       // The blob name is the entire key including parent folders. Keep only the filename.
       val fileName = Path(blob.name).fileName.toString()
-      InputImage(fileName, URI.create("gs://${blob.bucket}/${blob.name}"))
+      InputImage(fileName, URI.create("gs://${blob.bucket}/${blob.name}"), localPath = null)
     }
 }
 
@@ -65,6 +65,10 @@ fun fetchRemoteImages(inputImages: List<InputImage>): List<InputImage> {
   val localRoot = Files.createTempDirectory("images").toFile()
   // Delete it on process exit.
   Runtime.getRuntime().addShutdownHook(Thread { FileUtils.forceDelete(localRoot) })
+
+  // Refactor? Divide into local + remote.
+  // Move remote fetching to subroutine.
+  // Return combination of both.
 
   // Collect all remote paths that need downloading
   val remoteBlobs = inputImages.filter { it.localPath == null }.map { BlobId.fromGsUtilUri(it.uri.toString()) }

--- a/src/main/java/KotlinMain.kt
+++ b/src/main/java/KotlinMain.kt
@@ -45,25 +45,22 @@ class InitializeProject : CliktCommand() {
 
     val project = Projects.createProject(directory, BufferedImage::class.java)
 
+    logger.info("Discovering input files...")
     var inputImages = getImageInputs(args.imagesPath, imageFilter = imageFilter, extension = ".tiff")
 
+    logger.info("Fetching remote image files...")
     inputImages = fetchRemoteImages(inputImages)
 
     logger.info("Detected ${inputImages.size} input images: $inputImages")
 
     project.addImages(inputImages)
 
-    val wholeCellFiles = mutableListOf<File>()
-    val directoryOfMasks = File(args.segMasksPath)
-    if (directoryOfMasks.exists()) {
-      logger.info("Discovering mask files...")
+    logger.info("Discovering mask files...")
+    var wholeCellInputs = getImageInputs(args.segMasksPath, extension = "_WholeCellMask.tiff")
+    logger.info("Fetching remote mask files...")
+    wholeCellInputs = fetchRemoteImages(wholeCellInputs)
 
-      directoryOfMasks.walk().forEach {
-        if (it.isFile && it.name.endsWith("_WholeCellMask.tiff")) {
-          wholeCellFiles.add(it)
-        }
-      }
-    }
+    val wholeCellFiles = wholeCellInputs.mapNotNull { it.localPath }.map { File(it) }
 
     if (wholeCellFiles.isNotEmpty()) {
       project.imageList.forEach() { entry ->

--- a/src/main/java/KotlinMain.kt
+++ b/src/main/java/KotlinMain.kt
@@ -53,17 +53,19 @@ class InitializeProject : CliktCommand() {
 
     project.addImages(inputImages)
 
+    val wholeCellFiles = mutableListOf<File>()
     val directoryOfMasks = File(args.segMasksPath)
     if (directoryOfMasks.exists()) {
       logger.info("Discovering mask files...")
-      val wholeCellFiles = mutableListOf<File>()
 
       directoryOfMasks.walk().forEach {
         if (it.isFile && it.name.endsWith("_WholeCellMask.tiff")) {
           wholeCellFiles.add(it)
         }
       }
+    }
 
+    if (wholeCellFiles.isNotEmpty()) {
       project.imageList.forEach() { entry ->
         val imgName = entry.imageName
 

--- a/src/main/java/KotlinMain.kt
+++ b/src/main/java/KotlinMain.kt
@@ -2,13 +2,8 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.groups.groupChoice
 import com.github.ajalt.clikt.parameters.groups.required
 import com.github.ajalt.clikt.parameters.options.option
-import ij.IJ
-import ij.process.ColorProcessor
 import org.slf4j.LoggerFactory
-import qupath.imagej.processing.RoiLabeling
-import qupath.imagej.tools.IJTools
 import qupath.lib.analysis.features.ObjectMeasurements
-import qupath.lib.objects.PathObjects
 import qupath.lib.projects.Projects
 import qupath.lib.regions.ImagePlane
 import qupath.lib.scripting.QP
@@ -83,30 +78,7 @@ class InitializeProject : CliktCommand() {
           return@forEach
         }
 
-        val imp = IJ.openImage(wholeCellMask1.absolutePath)
-        logger.info(imp.toString())
-        val n = imp.statistics.max.toInt()
-        logger.info("   Max Cell Label: $n")
-        if (n == 0) {
-          logger.info(" >>> No objects found! <<<")
-          return
-        }
-
-        val ip = imp.processor
-        if (ip is ColorProcessor) {
-          throw IllegalArgumentException("RGB images are not supported!")
-        }
-
-        val roisIJ = RoiLabeling.labelsToConnectedROIs(ip, n)
-        val rois = roisIJ.mapNotNull {
-          if (it == null) {
-            null
-          } else {
-            IJTools.convertToROI(it, 0.0, 0.0, downsample, plane)
-          }
-        }
-
-        val pathObjects = rois.map { PathObjects.createDetectionObject(it) }
+        val pathObjects = extractPathObjects(wholeCellMask1.canonicalPath, downsample, plane)
 
         logger.info("  Number of Pathobjects: ${pathObjects.size}")
         imageData.hierarchy.addObjects(pathObjects)

--- a/src/main/java/KotlinMain.kt
+++ b/src/main/java/KotlinMain.kt
@@ -8,9 +8,6 @@ import org.slf4j.LoggerFactory
 import qupath.imagej.processing.RoiLabeling
 import qupath.imagej.tools.IJTools
 import qupath.lib.analysis.features.ObjectMeasurements
-import qupath.lib.gui.commands.ProjectCommands
-import qupath.lib.images.ImageData
-import qupath.lib.images.servers.ImageServerProvider
 import qupath.lib.objects.PathObjects
 import qupath.lib.projects.Projects
 import qupath.lib.regions.ImagePlane
@@ -59,33 +56,7 @@ class InitializeProject : CliktCommand() {
 
     logger.info("Detected ${inputImages.size} input images: $inputImages")
 
-    inputImages.mapNotNull { input -> input.localPath?.let { File(it) } }.forEach { file ->
-      val imagePath = file.getCanonicalPath()
-      logger.debug("Considering: $imagePath")
-
-      val support = ImageServerProvider.getPreferredUriImageSupport(BufferedImage::class.java, imagePath)
-      val builder = support.builders[0]
-
-      if (builder == null) {
-        logger.info("No builder found for $imagePath; skipping")
-        return@forEach
-      }
-
-      logger.info("Adding ${file.name} using builder: ${builder.javaClass.simpleName}")
-
-      val entry = project.addImage(builder)
-
-      val imageData = entry.readImageData()
-      imageData.imageType = ImageData.ImageType.FLUORESCENCE
-      entry.saveImageData(imageData)
-
-      val img = ProjectCommands.getThumbnailRGB(imageData.server)
-      entry.thumbnail = img
-
-      entry.imageName = file.name
-    }
-
-    project.syncChanges()
+    project.addImages(inputImages)
 
     val directoryOfMasks = File(args.segMasksPath)
     if (directoryOfMasks.exists()) {


### PR DESCRIPTION
This supports `gs://` input paths for segmentation mask file roots.

Commit by commit review is encouraged. Most of this is actually extracting/moving code.

Along with the previous #18 , this fixes #14 