### PR TITLE
Upload remote projects to cloud storage

### DIFF
--- a/src/main/java/KotlinMain.kt
+++ b/src/main/java/KotlinMain.kt
@@ -37,13 +37,9 @@ class InitializeProject : CliktCommand() {
     val downsample = 1.0
     val plane = ImagePlane.getDefaultPlane()
 
-    val directory = File(args.projectPath)
-    if (!directory.exists()) {
-      logger.info("No project directory, creating one!")
-      directory.mkdirs()
-    }
+    val projectDirectory = makeProjectDirectory(args.projectPath)
 
-    val project = Projects.createProject(directory, BufferedImage::class.java)
+    val project = Projects.createProject(projectDirectory, BufferedImage::class.java)
 
     logger.info("Discovering input files...")
     var inputImages = getImageInputs(args.imagesPath, imageFilter = imageFilter, extension = ".tiff")
@@ -116,6 +112,7 @@ class InitializeProject : CliktCommand() {
     }
 
     project.syncChanges()
+    uploadRemoteProject(projectDirectory, args.projectPath)
     logger.info("Done.")
   }
 }


### PR DESCRIPTION
If the project directory is cloud storage, then create a temporary working directory for project output.

Then, when completing the operation, if the project directory is remote, upload the working directory's content using `gcloud storage cp`.

Fixes #15