### PR TITLE
Export measurement reports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '8.1.1'
     id 'org.jetbrains.kotlin.jvm'
     id 'application'
+    id 'org.openjfx.javafxplugin' version '0.1.0'
 }
 
 group = 'org.example'
@@ -24,6 +25,14 @@ java {
 
 application {
     mainClass.set('KotlinMainKt')
+}
+
+// I'm not sure how much we truly use javafx.
+// It gets exercised during measurement export.
+// If we can remove this … or use less … we should.
+javafx {
+    version = '21'
+    modules = ['javafx.controls', 'javafx.fxml']
 }
 
 dependencies {

--- a/src/main/java/Inputs.kt
+++ b/src/main/java/Inputs.kt
@@ -149,7 +149,7 @@ fun prepWorkingDirectory(path: String): File {
   return localRoot
 }
 
-fun uploadRemoteProject(localFile: File, remotePathRoot: String) {
+fun uploadToRemote(localFile: File, remotePathRoot: String) {
   // Not remote? Nothing to do.
   if (!remotePathRoot.startsWith("gs://")) {
     return

--- a/src/main/java/Inputs.kt
+++ b/src/main/java/Inputs.kt
@@ -134,17 +134,17 @@ fun fetchRemoteImages(inputImages: List<InputImage>): List<InputImage> {
   }
 }
 
-fun makeProjectDirectory(projectPath: String): File {
+fun prepWorkingDirectory(path: String): File {
   // Not remote? Just return the directory.
-  if (!projectPath.startsWith("gs://")) {
-    return File(projectPath).apply { mkdirs() }
+  if (!path.startsWith("gs://")) {
+    return File(path).apply { mkdirs() }
   }
 
   // Remote: Create a temporary location to store output files for upload.
-  val localRoot = Files.createTempDirectory("qupath_project").toFile()
+  val localRoot = Files.createTempDirectory("qupath_workdir").toFile()
   Runtime.getRuntime().addShutdownHook(Thread { FileUtils.forceDelete(localRoot) })
 
-  logger.info("Creating project working directory: $localRoot")
+  logger.info("Prepped temporary local working directory: $localRoot")
 
   return localRoot
 }

--- a/src/main/java/Invocation.kt
+++ b/src/main/java/Invocation.kt
@@ -7,6 +7,7 @@ sealed class Invocation(name: String) : OptionGroup(name) {
   abstract val imagesPath: String
   abstract val segMasksPath: String
   abstract val projectPath: String
+  abstract val reportsPath: String
 }
 
 class WorkspaceLocation : Invocation("workspace") {
@@ -22,6 +23,9 @@ class WorkspaceLocation : Invocation("workspace") {
   private val projectSubdir: String by option(
     "--project-subdir", help = "Name of the folder to save QuPath project",
   ).default("QUPATH")
+  private val reportSubdir: String by option(
+    "--reports-subdir", help = "Name of the folder for QuPath measurements",
+  ).default("REPORTS")
 
   override val imagesPath: String
     get() = "$workspacePath/$imagesSubdir"
@@ -29,6 +33,8 @@ class WorkspaceLocation : Invocation("workspace") {
     get() = "$workspacePath/$segMasksSubdir"
   override val projectPath: String
     get() = "$workspacePath/$projectSubdir"
+  override val reportsPath: String
+    get() = "$workspacePath/$reportSubdir"
 }
 
 class ExplicitLocations : Invocation("explicit") {
@@ -41,6 +47,8 @@ class ExplicitLocations : Invocation("explicit") {
   override val projectPath: String by option(
     "--project-path", help = "Directory to save QuPath project",
   ).required()
-  val outputPath: String? by option(help = "Output path for QuPath measurements")
+  override val reportsPath: String by option(
+    "--reports-path", help = "Output path for QuPath measurements",
+  ).required()
 }
 

--- a/src/main/java/KotlinMain.kt
+++ b/src/main/java/KotlinMain.kt
@@ -1,7 +1,9 @@
+import Main.Companion.logger
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.groups.groupChoice
 import com.github.ajalt.clikt.parameters.groups.required
 import com.github.ajalt.clikt.parameters.options.option
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import qupath.lib.analysis.features.ObjectMeasurements
 import qupath.lib.projects.Projects
@@ -13,8 +15,14 @@ import java.awt.image.BufferedImage
 import java.io.File
 import kotlin.math.roundToInt
 
+class Main {
+  companion object {
+    val logger: Logger = LoggerFactory.getLogger(Main::class.java)
+  }
+}
+
 fun main(args: Array<String>) {
-  LoggerFactory.getLogger(InitializeProject::class.java).info("Initializing QuPath project")
+  logger.info("Initializing QuPath project")
 
   // This makes sure the scripting.QP import doesn't get "optimized" away
   // We need the import so that various static initializers are run.
@@ -30,8 +38,6 @@ class InitializeProject : CliktCommand() {
   ).required()
 
   private val imageFilter: String? by option("--image-filter", help = "Filter for image names (file base name)")
-
-  private val logger = LoggerFactory.getLogger(InitializeProject::class.java)
 
   override fun run() {
     val downsample = 1.0

--- a/src/main/java/KotlinMain.kt
+++ b/src/main/java/KotlinMain.kt
@@ -43,7 +43,7 @@ class InitializeProject : CliktCommand() {
     val downsample = 1.0
     val plane = ImagePlane.getDefaultPlane()
 
-    val projectDirectory = makeProjectDirectory(args.projectPath)
+    val projectDirectory = prepWorkingDirectory(args.projectPath)
 
     val project = Projects.createProject(projectDirectory, BufferedImage::class.java)
 
@@ -120,7 +120,8 @@ class InitializeProject : CliktCommand() {
     project.syncChanges()
 
     logger.info("Outputting reports to: ${args.reportsPath}")
-    outputReports(args.reportsPath, project)
+    val reportsWorkdir = prepWorkingDirectory(args.reportsPath)
+    outputReports(reportsWorkdir, project)
 
     uploadRemoteProject(projectDirectory, args.projectPath)
     logger.info("Done.")

--- a/src/main/java/KotlinMain.kt
+++ b/src/main/java/KotlinMain.kt
@@ -118,6 +118,10 @@ class InitializeProject : CliktCommand() {
     }
 
     project.syncChanges()
+
+    logger.info("Outputting reports to: ${args.reportsPath}")
+    outputReports(args.reportsPath, project)
+
     uploadRemoteProject(projectDirectory, args.projectPath)
     logger.info("Done.")
   }

--- a/src/main/java/KotlinMain.kt
+++ b/src/main/java/KotlinMain.kt
@@ -122,8 +122,9 @@ class InitializeProject : CliktCommand() {
     logger.info("Outputting reports to: ${args.reportsPath}")
     val reportsWorkdir = prepWorkingDirectory(args.reportsPath)
     outputReports(reportsWorkdir, project)
+    uploadToRemote(reportsWorkdir, args.reportsPath)
 
-    uploadRemoteProject(projectDirectory, args.projectPath)
+    uploadToRemote(projectDirectory, args.projectPath)
     logger.info("Done.")
   }
 }

--- a/src/main/java/Reports.kt
+++ b/src/main/java/Reports.kt
@@ -1,0 +1,36 @@
+import Reports.Companion.logger
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import qupath.lib.gui.tools.MeasurementExporter
+import qupath.lib.objects.PathDetectionObject
+import qupath.lib.projects.Project
+import qupath.lib.scripting.QP.buildFilePath
+import java.awt.image.BufferedImage
+import java.io.File
+
+class Reports {
+  companion object {
+    val logger: Logger = LoggerFactory.getLogger(Reports::class.java)
+  }
+}
+
+fun outputReports(outputRoot: String, project: Project<BufferedImage>) {
+  File(outputRoot).mkdirs()
+
+  project.imageList.forEach {
+    val imgName = it.imageName.substringBefore(".")
+    val separator = "\t"
+    val exportType = PathDetectionObject::class.java
+    val outputFile = File(buildFilePath(outputRoot, imgName + "_QUANT.tsv"))
+
+    logger.info("Exporting measurements for $imgName to: ${outputFile.absolutePath}")
+
+    MeasurementExporter()
+      .imageList(listOf(it)) // Images from which measurements will be exported
+      .separator(separator) // Character that separates values
+      .exportType(exportType) // Type of objects to export
+      .exportMeasurements(outputFile) // Start the export process
+  }
+
+  logger.info("Done exporting measurements.")
+}

--- a/src/main/java/Reports.kt
+++ b/src/main/java/Reports.kt
@@ -4,9 +4,9 @@ import org.slf4j.LoggerFactory
 import qupath.lib.gui.tools.MeasurementExporter
 import qupath.lib.objects.PathDetectionObject
 import qupath.lib.projects.Project
-import qupath.lib.scripting.QP.buildFilePath
 import java.awt.image.BufferedImage
 import java.io.File
+import java.nio.file.Paths
 
 class Reports {
   companion object {
@@ -14,16 +14,14 @@ class Reports {
   }
 }
 
-fun outputReports(outputRoot: String, project: Project<BufferedImage>) {
-  File(outputRoot).mkdirs()
-
+fun outputReports(outputRoot: File, project: Project<BufferedImage>) {
   project.imageList.forEach {
     val imgName = it.imageName.substringBefore(".")
     val separator = "\t"
     val exportType = PathDetectionObject::class.java
-    val outputFile = File(buildFilePath(outputRoot, imgName + "_QUANT.tsv"))
+    val outputFile = Paths.get(outputRoot.canonicalPath, "${imgName}_QUANT.tsv").toFile()
 
-    logger.info("Exporting measurements for $imgName to: ${outputFile.absolutePath}")
+    logger.info("Exporting measurements for $imgName to: ${outputFile.canonicalPath}")
 
     MeasurementExporter()
       .imageList(listOf(it)) // Images from which measurements will be exported


### PR DESCRIPTION
Export measurement reports to TSV.

Supports local targets, as well as remote (creates temporary directory then uploads to remote).

Fixes #19 