### PR TITLE
Enable zip64 in jar (to support >65k files)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,12 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 }
 
+tasks {
+    shadowJar {
+        isZip64 = true
+    }
+}
+
 test {
     useJUnitPlatform()
 }


### PR DESCRIPTION
This seems to be a fairly standard approach. Let's care less about # files and more about overall container size (which we're working on stabilizing through this build process…).

Fixes #24 