### PR TITLE
Install GPG before fetching google's GPG key

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -15,9 +15,13 @@ RUN gradle shadowJar --no-daemon -Dorg.gradle.welcome=never
 # But for now– we're doing this.
 FROM eclipse-temurin:21-jre-jammy
 
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+RUN \
     apt-get update -y && \
+    apt-get install -y gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+    apt-get update -y -o Dir::Etc::sourcelist="sources.list.d/google-cloud-sdk.list" \
+                      -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && \
     apt-get install -y git google-cloud-sdk google-cloud-cli pigz openjfx && \
     rm -rf /var/lib/apt/lists/* && \
     gcloud config set storage/parallel_composite_upload_enabled True


### PR DESCRIPTION
The eclipse-temurin base image doesn't have gpg installed. We need it to set up Google's package repository (for the sdk).

This change moves the update to the beginning, then fetches GPG, then proceeds as usual except that we only update the new Google repository the second time.

🤞🏻  maybe, hopefully will address issue #30


Paired with @WeihaoGe1009 