### PR TITLE
Copy directory contents, not directory itself

### DIFF
--- a/src/main/java/Inputs.kt
+++ b/src/main/java/Inputs.kt
@@ -158,9 +158,9 @@ fun uploadToRemote(localFile: File, remotePathRoot: String) {
   logger.info("Uploading $localFile to $remotePathRoot")
 
   try {
-    val proc = ProcessBuilder(*arrayOf("gcloud", "storage", "cp", "-r", localFile.path, remotePathRoot))
-      //.redirectOutput(ProcessBuilder.Redirect.DISCARD)
-      //.redirectError(ProcessBuilder.Redirect.DISCARD)
+    val proc = ProcessBuilder(*arrayOf("gcloud", "storage", "cp", "-r", "${localFile.canonicalPath}/*", remotePathRoot))
+      .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+      .redirectError(ProcessBuilder.Redirect.DISCARD)
       .start()
 
     proc.waitFor(60, TimeUnit.MINUTES)


### PR DESCRIPTION
If we have:

dir
\- file1
\- file2

and then do gcloud cp -r dir gs://my-bucket/dir

we'll end up with dir inside the cloud dir.

Instead let's do: cp -r dir/*
to treat local & target roots as roots.

Related to #34 