### PR TITLE
Ingest nucleus data [WIP]

### DIFF
--- a/src/main/java/Images.kt
+++ b/src/main/java/Images.kt
@@ -56,7 +56,7 @@ fun Project<BufferedImage>.addImages(inputImages: List<InputImage>) {
   this.syncChanges()
 }
 
-fun extractPathObjects(
+fun extractWholeCellObjects(
   maskPath: String,
   downsample: Double = 1.0,
   imagePlane: ImagePlane = ImagePlane.getDefaultPlane(),
@@ -85,4 +85,64 @@ fun extractPathObjects(
   }
 
   return rois.map { PathObjects.createDetectionObject(it) }
+}
+
+// NOTE: this does not work if the nucleus & whole-cell masks
+// have different numbers of objects.
+fun extractCellObjects(
+  nucleusMaskPath: String,
+  wholecellMaskPath: String,
+  downsample: Double = 1.0,
+  imagePlane: ImagePlane = ImagePlane.getDefaultPlane(),
+): List<PathObject> {
+  val nucleusImg = IJ.openImage(nucleusMaskPath)
+  val wholecellImg = IJ.openImage(wholecellMaskPath)
+
+  val nucleusProcessor = nucleusImg.processor
+  if (nucleusProcessor is ColorProcessor) {
+    throw IllegalArgumentException("RGB images are not supported!")
+  }
+  val wholecellProcessor = wholecellImg.processor
+  if (wholecellProcessor is ColorProcessor) {
+    throw IllegalArgumentException("RGB images are not supported!")
+  }
+
+  logger.info(nucleusImg.toString())
+
+  val numNucleus = nucleusProcessor.statistics.max.toInt()
+  val numWholecell = wholecellProcessor.statistics.max.toInt()
+
+  if (numNucleus == 0) {
+    logger.info(" >>> No objects found! <<<")
+    return emptyList()
+  }
+
+  logger.info("   Max nucleus label: $numNucleus; max whole-cell label: $numWholecell")
+
+  val nucleusRoisIJ = RoiLabeling.labelsToConnectedROIs(nucleusProcessor, numNucleus)
+  val nucleusRois = nucleusRoisIJ.mapNotNull {
+    if (it == null) {
+      null
+    } else {
+      IJTools.convertToROI(it, 0.0, 0.0, downsample, imagePlane)
+    }
+  }
+  val wholecellRoisIJ = RoiLabeling.labelsToConnectedROIs(wholecellProcessor, numWholecell)
+  val wholecellRois = wholecellRoisIJ.mapNotNull {
+    if (it == null) {
+      null
+    } else {
+      IJTools.convertToROI(it, 0.0, 0.0, downsample, imagePlane)
+    }
+  }
+
+  return nucleusRois.mapIndexedNotNull { index, nucleusRoi ->
+    val cellRoi = wholecellRois.getOrNull(index)
+    if (cellRoi == null) {
+      logger.warn("No whole-cell ROI found for nucleus ROI $index")
+      return@mapIndexedNotNull null
+    } else {
+      PathObjects.createCellObject(cellRoi, nucleusRoi, null, null)
+    }
+  }
 }

--- a/src/main/java/Invocation.kt
+++ b/src/main/java/Invocation.kt
@@ -19,7 +19,7 @@ class WorkspaceLocation : Invocation("workspace") {
   ).default("OMETIFF")
   private val segMasksSubdir: String by option(
     "--segmasks-subdir", help = "Name of the folder containing segmentation masks",
-  ).default("SEGMASKS")
+  ).default("SEGMASK")
   private val projectSubdir: String by option(
     "--project-subdir", help = "Name of the folder to save QuPath project",
   ).default("QUPATH")

--- a/src/main/java/KotlinMain.kt
+++ b/src/main/java/KotlinMain.kt
@@ -49,12 +49,10 @@ class InitializeProject : CliktCommand() {
 
     logger.info("Discovering input files...")
     var inputImages = getImageInputs(args.imagesPath, imageFilter = imageFilter, extension = ".tiff")
-
     logger.info("Fetching remote image files...")
     inputImages = fetchRemoteImages(inputImages)
 
-    logger.info("Detected ${inputImages.size} input images: $inputImages")
-
+    logger.info("Adding ${inputImages.size} input images: $inputImages")
     project.addImages(inputImages)
 
     logger.info("Discovering mask files...")

--- a/src/main/java/KotlinMain.kt
+++ b/src/main/java/KotlinMain.kt
@@ -135,6 +135,10 @@ class InitializeProject : CliktCommand() {
 
     logger.info("Discovering mask files...")
     var nucleusMaskInputs = getImageInputs(args.segMasksPath, extension = "_NucleusMask.tiff")
+    // Pass in an empty list of nucleus files to use only whole cell masks.
+    // This is because nucleus matching doesn't work yet when the number
+    // of whole-cells is different from the number of nuclei in the masks.
+    nucleusMaskInputs = listOf()
     var wholeCellInputs = getImageInputs(args.segMasksPath, extension = "_WholeCellMask.tiff")
     logger.info("Fetching remote mask files...")
     nucleusMaskInputs = fetchRemoteImages(nucleusMaskInputs)
@@ -145,10 +149,7 @@ class InitializeProject : CliktCommand() {
 
     if (wholeCellFiles.isNotEmpty()) {
       project.imageList.forEach() { entry ->
-        // Pass in an empty list of nucleus files to use only whole cell masks.
-        // This is because nucleus matching doesn't work yet when the number
-        // of whole-cells is different from the number of nuclei in the masks.
-        addImageObjects(entry, listOf(), wholeCellFiles, downsample, plane)
+        addImageObjects(entry, nucleusMaskFiles, wholeCellFiles, downsample, plane)
       }
     }
 


### PR DESCRIPTION
This is WIP to ingest nucleus data alongside whole-cell. But it doesn't work when the number of cells is different from the number of nuclei, in the mask files. We're adding it now to checkpoint the code. It never actually runs because we pass in an empty list of nucleus masks, even if some were detected.

We need to figure out what to do when we don't have the same number of nuclei & whole-cell. We could possibly use an algorithm that matches them based on the nucleus ROI being contained in the whole-cell ROI. That's a bit computationally intensive so we'd rather avoid if possible …

Stay tuned!

Paired with @WeihaoGe1009 