### PR TITLE
Match nuclei by 100% inclusion in cell, or best match

### DIFF
--- a/src/main/java/KotlinMain.kt
+++ b/src/main/java/KotlinMain.kt
@@ -138,7 +138,6 @@ class InitializeProject : CliktCommand() {
     // Pass in an empty list of nucleus files to use only whole cell masks.
     // This is because nucleus matching doesn't work yet when the number
     // of whole-cells is different from the number of nuclei in the masks.
-    nucleusMaskInputs = listOf()
     var wholeCellInputs = getImageInputs(args.segMasksPath, extension = "_WholeCellMask.tiff")
     logger.info("Fetching remote mask files...")
     nucleusMaskInputs = fetchRemoteImages(nucleusMaskInputs)


### PR DESCRIPTION
We previously matched nuclei based on being fully contained in the cell. We actually used the strict "contains" which meant the nucleus couldn't share a border with the cell. We relaxed that to "covers" which means they can share boundary pixels.

However we still found some nuclei weren't matching their cells because the nucleus boundaries extended by 1-2 pixels past the cell. So now we build a list of candidate matches based on nucleus and cell overlapping at all, which we then sort by the percentage of the nucleus that's contained in the cell.

The highest percentage matches are taken in order, until we have no more matches at which point we stop.

Paired with @WeihaoGe1009 

Fixes #38  with a followup in #44