### PR TITLE
Add launch-build.sh helper

### DIFF
--- a/.envrc.template
+++ b/.envrc.template
@@ -1,0 +1,1 @@
+export GCP_ARTIFACT_REPOSITORY=the-repository-name

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+/.envrc
 
 ### IntelliJ IDEA ###
 .idea/modules.xml

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Tools to initialize a [QuPath project](https://qupath.github.io/) from input fil
 
 ## Development
 
+### Cloud Build
+
+Launch cloud build jobs with `container/launch-build.sh`.
+
+Make sure your environment is set up. Copy `.envrc.template` to `.envrc` and set variables.
+
 ### Github
 
 Set these repository variables:

--- a/container/launch-build.sh
+++ b/container/launch-build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [[ -z "$GCP_ARTIFACT_REPOSITORY" ]]; then
+  echo "Error: GCP_ARTIFACT_REPOSITORY is not set."
+  exit 1
+fi
+
+if [ -f "Dockerfile" ]; then
+  echo "Error: run from repository root."
+  exit 1
+fi
+
+gcloud builds submit \
+  --region=us-central1 \
+  --config=container/build-gcp-container.yaml \
+  --substitutions _GCP_REPOSITORY=$GCP_ARTIFACT_REPOSITORY \
+  .


### PR DESCRIPTION
Helper script for launching Cloud Build manually, when GitHub actions aren't available.